### PR TITLE
ci: install pytest in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
+          pip install pytest
       - name: Run tests
         run: python -m pytest -q


### PR DESCRIPTION
Fix CI by installing pytest before running tests.