### PR TITLE
ci: install dev deps and build package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,11 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - name: Install package
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
-          pip install pytest
+          pip install -e ".[dev]"
+      - name: Build package
+        run: python -m build
       - name: Run tests
         run: python -m pytest -q


### PR DESCRIPTION
Use dev extra for CI dependency install and add package build step.