### PR TITLE
fix: render inline code without surrounding spaces

### DIFF
--- a/slack_markdown_parser/converter.py
+++ b/slack_markdown_parser/converter.py
@@ -36,7 +36,7 @@ def strip_zero_width_spaces(text: str) -> str:
 def add_zero_width_spaces_to_markdown(text: str) -> str:
     """Stabilize markdown rendering by padding style markers with ZWSP.
 
-    Code fences and inline code segments are preserved untouched.
+    Code fences are preserved untouched.
     """
     if not text:
         return text
@@ -55,7 +55,7 @@ def add_zero_width_spaces_to_markdown(text: str) -> str:
         if not segment:
             return segment
         patterns = [
-            r"(?<!`)`[^`]+`(?!`)",
+            r"(?<!`)`[^`\n]+`(?!`)",
             r"(?<!\*)\*\*(.+?)\*\*(?!\*)",
             r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)",
             r"~~(.+?)~~",
@@ -69,10 +69,10 @@ def add_zero_width_spaces_to_markdown(text: str) -> str:
             )
         return segment
 
-    code_pattern = r"(```.*?```|`[^`]*`)"
-    parts = re.split(code_pattern, text, flags=re.DOTALL)
+    code_fence_pattern = r"(```.*?```)"
+    parts = re.split(code_fence_pattern, text, flags=re.DOTALL)
     for idx, part in enumerate(parts):
-        if re.fullmatch(code_pattern, part or "", flags=re.DOTALL):
+        if re.fullmatch(code_fence_pattern, part or "", flags=re.DOTALL):
             continue
         parts[idx] = wrap_segment(part)
     return "".join(parts)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -103,6 +103,13 @@ def test_zero_width_space_not_inserted_inside_code_fence() -> None:
     assert "**bold**\u200b" in converted
 
 
+def test_inline_code_without_spaces_is_padded_with_zwsp() -> None:
+    text = "詳細ログIDは`run-20260305-02`です。"
+    converted = add_zero_width_spaces_to_markdown(text)
+
+    assert "詳細ログIDは\u200b`run-20260305-02`\u200bです。" == converted
+
+
 def test_blocks_to_plain_text_and_fallback_generation() -> None:
     raw = """# Title
 


### PR DESCRIPTION
## Summary\n- make inline code () eligible for ZWSP padding when adjacent to Japanese text\n- keep code fences untouched\n- add regression test for no-space inline code\n\n## Why\nSlack markdown rendering can miss inline code style when backticks are directly adjacent to non-space characters (e.g. Japanese). This aligns inline-code behavior with bold/italic/strike handling.