### PR TITLE
chore: bump version to 2.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slack-markdown-parser"
-version = "2.0.0"
+version = "2.0.1"
 description = "Convert LLM Markdown into Slack Block Kit markdown/table messages"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/slack_markdown_parser/__init__.py
+++ b/slack_markdown_parser/__init__.py
@@ -1,6 +1,6 @@
 """slack-markdown-parser public package API."""
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __license__ = "MIT"
 
 from .converter import (


### PR DESCRIPTION
## Summary\n- bump package version from 2.0.0 to 2.0.1\n- align metadata for the latest inline-code rendering fix release\n\n## Notes\nThis prepares the v2.0.1 tag so dependent bots can install the updated package via tag tarball URL.