### PR TITLE
chore: ignore serena metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,6 @@ python/
 # IDE / OS
 .vscode/
 .idea/
+.serena/
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary
- add `.serena/` to `.gitignore`
- keep local Serena project metadata out of commits

## Testing
- not run (gitignore-only change)