### PR TITLE
chore: bump version to 2.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slack-markdown-parser"
-version = "2.0.1"
+version = "2.0.2"
 description = "Convert LLM Markdown into Slack Block Kit markdown/table messages"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/slack_markdown_parser/__init__.py
+++ b/slack_markdown_parser/__init__.py
@@ -1,6 +1,6 @@
 """slack-markdown-parser public package API."""
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 __license__ = "MIT"
 
 from .converter import (


### PR DESCRIPTION
## Summary
- bump the package version from `2.0.1` to `2.0.2`
- prepare the current mainline changes for the next public release

## Included since v2.0.1
- ZWSP padding fix for punctuation-adjacent markdown
- parser edge case improvements
- English/Japanese README and spec split for public-facing docs
- repository ignore cleanup for local Serena metadata

## Testing
- pytest
- python -m build
- twine check dist/slack_markdown_parser-2.0.2*