### PR TITLE
Release 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on Keep a Changelog, and the project follows Semantic Versio
 
 ## [Unreleased]
 
+## [2.3.1] - 2026-04-10
+
+### Fixed
+
+- Stopped `preserve_visual_blank_lines` from inserting visual-only blank-line placeholders inside fenced code blocks.
+- Kept fallback plain text stable when visual blank-line placeholders are enabled alongside parser-added spacing markers around emphasis or inline code.
+
 ## [2.3.0] - 2026-04-10
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slack-markdown-parser"
-version = "2.3.0"
+version = "2.3.1"
 description = "Convert LLM Markdown into Slack Block Kit markdown/table messages"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/slack_markdown_parser/__init__.py
+++ b/slack_markdown_parser/__init__.py
@@ -1,6 +1,6 @@
 """slack-markdown-parser public package API."""
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 __license__ = "MIT"
 
 from .converter import (


### PR DESCRIPTION
## Summary
- bump package version to 2.3.1
- document the fenced-code and fallback-text fixes in the changelog
- align the repository with the already-published 2.3.1 package

## Checks
- uv run --with pytest python -m pytest -q
- uv run --with ruff python -m ruff check .
- uv run --with black python -m black --check .
- uv build
- uv run --with twine python -m twine check dist/slack_markdown_parser-2.3.1.tar.gz dist/slack_markdown_parser-2.3.1-py3-none-any.whl