### PR TITLE
ci: harden trusted publishing release flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,10 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
       - name: Resolve version from tag
         id: version
         shell: bash
@@ -55,7 +59,7 @@ jobs:
           PACKAGE_NAME: slack-markdown-parser
           PACKAGE_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          python - <<'PY'
+          python3 - <<'PY'
           import json
           import os
           import urllib.request
@@ -68,7 +72,7 @@ jobs:
           try:
               with urllib.request.urlopen(url, timeout=10) as response:
                   payload = json.load(response)
-              exists = bool(payload.get("releases", {}).get(version))
+              exists = version in payload.get("releases", {})
           except Exception as exc:
               print(f"PyPI preflight check failed ({exc}); continuing with publish attempt.")
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,5 +45,54 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
+      - name: Resolve version from tag
+        id: version
+        shell: bash
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Check whether version already exists on PyPI
+        id: pypi
+        env:
+          PACKAGE_NAME: slack-markdown-parser
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          package = os.environ["PACKAGE_NAME"]
+          version = os.environ["PACKAGE_VERSION"]
+          url = f"https://pypi.org/pypi/{package}/json"
+          exists = False
+
+          try:
+              with urllib.request.urlopen(url, timeout=10) as response:
+                  payload = json.load(response)
+              exists = bool(payload.get("releases", {}).get(version))
+          except Exception as exc:
+              print(f"PyPI preflight check failed ({exc}); continuing with publish attempt.")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"already_published={'true' if exists else 'false'}\n")
+          PY
+      - name: Skip publish because version already exists
+        if: steps.pypi.outputs.already_published == 'true'
+        run: |
+          echo "Version ${{ steps.version.outputs.version }} already exists on PyPI."
+          echo "Skipping Trusted Publisher upload and continuing to GitHub Release creation."
       - name: Publish to PyPI
+        if: steps.pypi.outputs.already_published != 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub release
+    needs: publish
+    if: needs.publish.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create or update GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,3 +65,14 @@ Helpful reports usually include:
 
 Project maintainers keep release history in `CHANGELOG.md`.
 If your pull request affects users, please include a short changelog note in the PR description.
+
+## Maintainer releases
+
+Package publishing is handled by GitHub Actions Trusted Publishing only.
+Maintainers should create or update the changelog, create an annotated tag like
+`v2.3.2`, and push the tag to GitHub.
+
+Do not publish with `twine upload`, `uv publish`, or a local PyPI API token for
+this repository. If a tag points to a version that is already present on PyPI,
+the publish workflow now skips the upload and still creates the matching GitHub
+Release so the repository release list stays current.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dev = [
   "pytest>=8.0.0",
   "pytest-cov>=5.0.0",
   "ruff>=0.6.0",
-  "twine>=5.1.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- skip Trusted Publisher uploads when the tagged version already exists on PyPI
- create GitHub Releases even when PyPI upload is skipped
- document Trusted Publisher-only maintainer release steps and remove local twine dev dependency

## Testing
- validated workflow YAML parses with Ruby's YAML loader
- backfilled GitHub Releases for v2.3.0 and v2.3.1
- did not run the Python test suite (workflow/docs/dependency-only changes)