### PR TITLE
Release v2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on Keep a Changelog, and the project follows Semantic Versio
 
 ## [Unreleased]
 
+## [2.3.2] - 2026-04-17
+
+### Fixed
+
+- Stopped `preserve_visual_blank_lines` from keeping ordered-list context open after list items, including continued items, nested lists, and ordered-list paragraph interruption edge cases.
+- Avoided false-positive list-context detection for indented non-list lines and thematic breaks, so visible blank-line preservation no longer regresses on inputs like `    1. not-a-list` or `- - -`.
+
 ## [2.3.1] - 2026-04-10
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slack-markdown-parser"
-version = "2.3.1"
+version = "2.3.2"
 description = "Convert LLM Markdown into Slack Block Kit markdown/table messages"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/slack_markdown_parser/__init__.py
+++ b/slack_markdown_parser/__init__.py
@@ -1,6 +1,6 @@
 """slack-markdown-parser public package API."""
 
-__version__ = "2.3.1"
+__version__ = "2.3.2"
 __license__ = "MIT"
 
 from .converter import (


### PR DESCRIPTION
## Summary\n- bump package version to 2.3.2\n- record the ordered-list blank-line parser fixes in the changelog\n\n## Validation\n- .venv/bin/python -m pytest -q\n- .venv/bin/python -m ruff check .\n- .venv/bin/python -m black --check .\n- uv run --extra dev python -m build