### PR TITLE
docs: note Slack mobile list-continuation marker duplication as known issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and the project follows Semantic Versio
 
 ## [Unreleased]
 
+### Documentation
+
+- Documented the Slack mobile `markdown` block limitation where list-item continuation lines are re-prefixed with the list marker, and linked the tracking issue so users can check upstream status instead of expecting a parser-side workaround.
+
 ## [2.3.2] - 2026-04-17
 
 ### Fixed

--- a/README-ja.md
+++ b/README-ja.md
@@ -59,6 +59,7 @@ Slack 側の制約として残るもの:
 - `markdown` ブロック内の生 Markdown テーブルは一部環境では表示されるが、安定性では明示的な Slack `table` ブロックの方が上
 - Markdown 画像記法は `markdown` ブロック内では埋め込み画像にならない
 - 数式, 生 HTML, HTML comment, `<details>`, admonition 記法, Mermaid は特別な表示にならず、テキストまたはコードとして出る
+- Slack **モバイル**アプリは、`markdown` ブロック内のリスト項目に属する継続行（CommonMark で同じリスト項目に紐づくインデントされた段落）の先頭に、リストマーカーを再付加してしまう。例: `1. 見出し` の次にインデントされた継続段落を置くと、モバイルでは `1. 見出し` と `1.継続行...` のように番号が重複して表示される。Slack デスクトップ／Web は同じペイロードを正しく描画する。これはパーサー側の不具合ではなく Slack クライアントのレンダリング挙動。追跡: [issue #45](https://github.com/darkgaldragon/slack-markdown-parser/issues/45)。
 
 このライブラリが吸収するもの:
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Known Slack-side limitations:
 - Raw Markdown tables inside `markdown` blocks now render in some newer Slack environments, but explicit Slack `table` blocks remain the reliable option across workspaces and delivery paths
 - Markdown image syntax does not become an embedded image in `markdown` blocks
 - Math, raw HTML, HTML comments, `<details>`, admonition syntax, and Mermaid are rendered as plain text or code, not as rich features
+- The Slack **mobile** app re-prefixes the list marker onto each continuation line of a list item inside `markdown` blocks (e.g. `1. Heading` followed by an indented paragraph shows as `1. Heading` / `1.continuation` on mobile, while Slack desktop and Slack Web render the same payload correctly). This is a Slack client-side rendering behavior, not a parser bug. Tracking: [issue #45](https://github.com/darkgaldragon/slack-markdown-parser/issues/45).
 
 What this library compensates for:
 


### PR DESCRIPTION
## Summary

- Document the Slack mobile `markdown`-block rendering quirk where list-item continuation lines are re-prefixed with the list marker, so readers understand this is a Slack client-side behavior rather than a parser bug.
- Add the known limitation to both `README.md` and `README-ja.md` under the existing "Known Slack-side limitations" list, with a link to the tracking issue.
- Add a `Documentation` entry under `CHANGELOG.md` Unreleased.

No code changes. Parser output keeps producing valid CommonMark loose lists, which render correctly on Slack desktop and Slack Web.

Refs: #45

## Test plan

- [x] `README.md` renders the new bullet under "Known Slack-side limitations" with a live link to issue #45.
- [x] `README-ja.md` renders the same limitation in Japanese in the matching section.
- [x] `CHANGELOG.md` Unreleased now contains a `Documentation` entry describing the note.
- [x] No behavioral code changed; existing test suite still passes (`uv run pytest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)