### PR TITLE
[codex] Update artifact actions for Node 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build package
         run: python -m build
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-package-distributions
           path: dist/
@@ -41,7 +41,7 @@ jobs:
       id-token: write
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: python-package-distributions
           path: dist/


### PR DESCRIPTION
## Summary
- Update the publish workflow artifact upload/download actions to Node 24-backed versions.
- Replace `actions/upload-artifact@v4` with `actions/upload-artifact@v7.0.1`.
- Replace `actions/download-artifact@v4` with `actions/download-artifact@v8.0.1`.

## Why
GitHub Actions now warns about Node.js 20 deprecation for JavaScript actions. The release workflow itself is healthy, but these action upgrades remove the deprecation warning before Node 20 runner support is removed.

## Validation
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/publish.yml'); puts 'publish.yml YAML parses'"`
- `uv run python -m pytest -q`
- `uv run python -m ruff check .`
- `uv run python -m black --check .`
- `uv run python -m build`

Note: `actionlint` is not installed locally, so workflow linting was limited to YAML parsing and GitHub Actions CI.