### PR TITLE
Release v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, and the project follows Semantic Versio
 
 ## [Unreleased]
 
+## [2.4.1] - 2026-05-29
+
 ### Fixed
 
 - Stopped punctuation-terminated emphasis from leaking its literal markers (`**`, `*`, `~~`) in `markdown` blocks. A ZWSP placed just outside a closing marker broke Slack's CommonMark right-flanking check whenever the last inner character was punctuation (e.g. `- **項目:**` at a line end, or `**70.9%→83.0%**、` before CJK punctuation), exposing the raw markers. Chunk boundaries are now treated as safe so no stray ZWSP is appended at line/text ends, and when a marker sits against inner punctuation a ZWSP is inserted just inside it so the run flanks via rule 2a regardless of the following character — including before CJK text and CJK punctuation that Slack does not accept as a flanking neighbor.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slack-markdown-parser"
-version = "2.4.0"
+version = "2.4.1"
 description = "Convert LLM Markdown into Slack Block Kit messages"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/slack_markdown_parser/__init__.py
+++ b/slack_markdown_parser/__init__.py
@@ -1,6 +1,6 @@
 """slack-markdown-parser public package API."""
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 __license__ = "MIT"
 
 from .converter import (


### PR DESCRIPTION
Patch release for the punctuation-terminated emphasis rendering fix (#49).

## Changes
- Bump version `2.4.0` → `2.4.1` (`pyproject.toml`, `slack_markdown_parser/__init__.py`).
- Promote the `[Unreleased]` CHANGELOG entries to `[2.4.1] - 2026-05-29`.

## Included since 2.4.0
- Stopped punctuation-terminated emphasis from leaking literal `**`/`*`/`~~` markers in `markdown` blocks (line-end colon-bold, `%`-end before CJK punctuation, colon-bold before CJK text).
- Stopped preserving English-like punctuation-flanked emphasis raw when its tight neighbor is non-ASCII punctuation.

Merging this and pushing the `v2.4.1` tag publishes to PyPI via the existing Trusted Publisher workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)