### PR TITLE
Release v2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ The format is based on Keep a Changelog, and the project follows Semantic Versio
 
 ## [Unreleased]
 
+## [2.4.2] - 2026-05-29
+
 ### Fixed
 
 - Stopped an unbalanced emphasis delimiter from corrupting unrelated, well-formed spans in the same block. The bold/italic/strikethrough patterns are matched with `re.DOTALL`, so a single stray `**` (for example a whitespace-flanked literal `**` in `閉じ ** が`, or an unclosed marker) shifted marker pairing across the whole block and flipped the protective ZWSP of nearby punctuation-terminated bold to the broken *outer* position, re-exposing the literal markers on Slack. `EMPHASIS_PATTERNS` now enforces CommonMark's minimal flanking requirement — an opening run is not followed by whitespace and a closing run is not preceded by whitespace — so a non-flanking stray marker stays literal and no longer disturbs its neighbours.
+- Bounded the `**` and `~~` emphasis bodies to a single delimiter run so a dangling opener with no valid closer of its own (for example `**oops **` or `**: x **` before a later `**…%**`) can no longer scan past the literal stray and steal a following well-formed span's closing marker, which had misplaced that span's protective ZWSP. The single-`*` italic body is intentionally left unbounded because italics legitimately wrap `**bold**`.
 
 ## [2.4.1] - 2026-05-29
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slack-markdown-parser"
-version = "2.4.1"
+version = "2.4.2"
 description = "Convert LLM Markdown into Slack Block Kit messages"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/slack_markdown_parser/__init__.py
+++ b/slack_markdown_parser/__init__.py
@@ -1,6 +1,6 @@
 """slack-markdown-parser public package API."""
 
-__version__ = "2.4.1"
+__version__ = "2.4.2"
 __license__ = "MIT"
 
 from .converter import (


### PR DESCRIPTION
Patch release bundling the unbalanced-emphasis-marker hardening from #52.

## Version
- `pyproject.toml` and `slack_markdown_parser/__init__.py`: `2.4.1` → `2.4.2`
- `CHANGELOG.md`: `[Unreleased]` promoted to `[2.4.2] - 2026-05-29`

## Included (from #52)
- Enforce CommonMark's minimal flanking on emphasis delimiters so a stray, whitespace-flanked `**` (e.g. the literal `**` in `閉じ ** が`) stays literal instead of shifting the pairing of nearby well-formed spans.
- Bound the `**`/`~~` bodies to a single delimiter run so a dangling opener cannot steal a later span's closing marker (Codex P2 on #52).

## Gate
`pytest` 109 passed · `ruff` clean · `black --check` clean · `python -m build` → `2.4.2` artifacts.

After merge, tagging `v2.4.2` triggers the Trusted-Publisher publish workflow (PyPI + GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)