### PR TITLE
Release v2.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, and the project follows Semantic Versio
 
 ## [Unreleased]
 
+## [2.4.3] - 2026-05-29
+
 ### Fixed
 
 - Stopped bare-URL autolinking from greedily swallowing trailing text. `normalize_bare_urls_for_slack_markdown` matched `https?://[^\s<]+`, so a scheme URL glued directly to following CJK text (e.g. `(https://example.com)**。に句点を直結。`) — common in Japanese, which puts no space after a URL — captured the closing paren, the `**` markers, the CJK punctuation, and the rest of the sentence into one `<…>` autolink, over-extending the link and exposing the literal `**`. The matched URL is now trimmed GFM-style: it stops at a doubled emphasis run (`**`/`~~`), at code/angle/pipe markers (`` ` ``, `<`, `>`, `|`), and at CJK punctuation (`、`/`。`/`」` …), and trailing punctuation (GFM's autolink set `! ? . , : * _ ~`, and an unbalanced `)`) is dropped while balanced parentheses are kept. `;` and quotes are kept (URL-legal), and a lone `*` (URL wildcards/queries) and CJK letters (IRIs / Unicode IDN hosts) are preserved.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slack-markdown-parser"
-version = "2.4.2"
+version = "2.4.3"
 description = "Convert LLM Markdown into Slack Block Kit messages"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/slack_markdown_parser/__init__.py
+++ b/slack_markdown_parser/__init__.py
@@ -1,6 +1,6 @@
 """slack-markdown-parser public package API."""
 
-__version__ = "2.4.2"
+__version__ = "2.4.3"
 __license__ = "MIT"
 
 from .converter import (


### PR DESCRIPTION
Patch release bundling the bare-URL autolink trimming from #54.

## Version
- `pyproject.toml` and `slack_markdown_parser/__init__.py`: `2.4.2` → `2.4.3`
- `CHANGELOG.md`: `[Unreleased]` promoted to `[2.4.3] - 2026-05-29`

## Included (from #54)
- `normalize_bare_urls_for_slack_markdown` trims a greedily matched bare URL (GFM-style) before wrapping it: stops at `**`/`~~` emphasis runs, code/angle/pipe markers, and CJK/full-width punctuation; drops trailing `! ? . , : * _ ~` and an unbalanced `)`. Single `*` (wildcards), `;`/quotes (URL-legal), and CJK letters/iteration marks (IRIs) are preserved.

## Gate
`pytest` 119 passed · `ruff` clean · `black --check` clean · `python -m build` → `2.4.3` artifacts.

Tagging `v2.4.3` after merge triggers the Trusted-Publisher publish workflow (PyPI + GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)