### PR TITLE
Release v2.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, and the project follows Semantic Versio
 
 ## [Unreleased]
 
+## [2.4.4] - 2026-06-10
+
 ### Fixed
 
 - Stopped a link wrapped entirely in emphasis (`**[text](url)**`, and the `*`/`_`/`__`/`~~`/`***` variants) from rendering as dead, literal text in `rich_text` contexts such as list items and table cells. The emphasis token pattern matched the whole `**[text](url)**` span before the link pattern got a chance, so `_create_rich_text_inline_elements` emitted the inner `[text](url)` as a styled plain-text run and the link was never clickable. When a styled (non-code) token's inner content is itself a complete markdown link, it now becomes a `link` element carrying that style (e.g. a bold link), matching the already-working emphasis-inside-the-brackets form (`[**text**](url)`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slack-markdown-parser"
-version = "2.4.3"
+version = "2.4.4"
 description = "Convert LLM Markdown into Slack Block Kit messages"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/slack_markdown_parser/__init__.py
+++ b/slack_markdown_parser/__init__.py
@@ -1,6 +1,6 @@
 """slack-markdown-parser public package API."""
 
-__version__ = "2.4.3"
+__version__ = "2.4.4"
 __license__ = "MIT"
 
 from .converter import (


### PR DESCRIPTION
Version bump to 2.4.4 (patch — Fixed only) and CHANGELOG section for the two rendering fixes:

- #56 — Slack mention tokens render as structured elements (pills) inside promoted list items and table cells, with the fallback text re-emitting live tokens
- #57 — links wrapped entirely in emphasis (`**[text](url)**` etc.) render as styled, clickable link elements in rich_text contexts
- #58 — internal consolidation of the plain-text downgrade walkers + downgrade-parity test matrix (no behavior change)

Both fixes were verified end-to-end against a real workspace (dry-run payloads, post-time API validation, rendered output via screenshot).

Local gate: pytest 145 passed / ruff / black --check / build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)