### PR TITLE
Update action-gh-release to v3 for Node 24 runtime

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,6 +97,6 @@ jobs:
       contents: write
     steps:
       - name: Create or update GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true


### PR DESCRIPTION
## Summary

The v2.4.4 publish run logged:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: softprops/action-gh-release@v2. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

Upstream's v3.0.0 is a runtime-only major release (Node 20 → 24, same inputs/outputs), and the `v2` floating tag intentionally stays on the Node 20 line — so the fix is moving the major tag to `@v3`. All other actions in `ci.yml` / `publish.yml` are already on Node 24-ready versions (updated in #48).

## Verification

- Confirmed `v3.0.0`'s `action.yml` declares `using: "node24"` and the release notes state no input/output changes.
- `publish.yml` only runs on `v*` tag pushes, so this path gets exercised at the next release; the step's `with:` block (`generate_release_notes`) is unchanged in v3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)