### PR TITLE
Release v2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog, and the project follows Semantic Versio
 
 ## [Unreleased]
 
+## [2.5.1] - 2026-06-11
+
+### Fixed
+
+- Stopped a lone `<` in a table cell from swallowing later cell separators. The cell splitter tracked angle brackets with a stateful flag that any `<` turned on and only a `>` turned off, so a bare `<` with no closing `>` on the same line — a comparison like `x < y` or a threshold like `< 100ms`, both common in LLM-generated tables — silently merged the remaining cells into one, shifted the columns, and filled the lost trailing cell with `-`. Pipes are now protected only inside valid Slack angle tokens (links, mentions, `<!date^...>`), which are consumed whole; a bare `<` stays literal. The heading+table-row splitter shares the same scan, so a `# Heading |a|b|` line now also splits when the heading contains a lone `<`, and standalone `parse_markdown_table` / `normalize_markdown_tables` now match the sanitized pipeline's behavior.
+
 ## [2.5.0] - 2026-06-11
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slack-markdown-parser"
-version = "2.5.0"
+version = "2.5.1"
 description = "Convert LLM Markdown into Slack Block Kit messages"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/slack_markdown_parser/__init__.py
+++ b/slack_markdown_parser/__init__.py
@@ -1,6 +1,6 @@
 """slack-markdown-parser public package API."""
 
-__version__ = "2.5.0"
+__version__ = "2.5.1"
 __license__ = "MIT"
 
 from .converter import (


### PR DESCRIPTION
## Summary

Release PR for v2.5.1 (PATCH), shipping the merged fix:

- #64 — stop a lone `<` in a table cell from swallowing later pipes (silent cell merging / column loss for comparison expressions and thresholds like `< 100ms`)

## Contents

- Version bump 2.5.0 → 2.5.1 (`pyproject.toml`, `__init__.py`)
- `CHANGELOG.md` 2.5.1 entry

After merge: tag `v2.5.1` on the merged main commit to trigger Trusted Publishing to PyPI and the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)