### PR TITLE
chore: gitignore local .claude directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ AGENTS.md
 CLAUDE.md
 .DS_Store
 Thumbs.db
+.claude
 
 # Local research / ad-hoc outputs
 output/


### PR DESCRIPTION
## Summary

Adds `.claude` to `.gitignore`. Claude Code writes project-local settings under `.claude/` (`settings.json` plus a personal `settings.local.json`), which was showing up as an untracked directory. This repo is public, so the personal local settings should stay out of version control — placed alongside the other local tool files already ignored (`AGENTS.md`, `CLAUDE.md`, `.DS_Store`).

No code or behavior changes; documentation/tooling hygiene only.

## Testing

- [x] `git status` no longer lists `.claude/`
- [x] No source, spec, or test files touched

## Documentation

- [x] README update not needed
- [x] Spec update not needed
- [x] Changelog note not needed (tooling hygiene, not a package change)

## Checklist

- [x] Tests added or updated when behavior changed (n/a)
- [x] Backward compatibility considered (n/a — ignore rule only)
- [x] Public API changes called out clearly (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)