### PR TITLE
Release v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, and the project follows Semantic Versio
 
 ## [Unreleased]
 
+## [2.7.0] - 2026-07-06
+
 ### Added
 
 - Exported `normalize_bare_urls_for_slack_markdown` as part of the public package API. It wraps bare URLs into Slack-friendly `<https://...>` autolink form, trimming each URL to its real extent (GFM-style) so adjacent CJK text and emphasis markers survive. The behavior is unchanged; only its name was already public-shaped while the function was reachable solely through the internal `slack_markdown_parser.converter` module, so it is now listed in `__all__` and the README utility tables.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slack-markdown-parser"
-version = "2.6.0"
+version = "2.7.0"
 description = "Convert LLM Markdown into Slack Block Kit messages"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/slack_markdown_parser/__init__.py
+++ b/slack_markdown_parser/__init__.py
@@ -1,6 +1,6 @@
 """slack-markdown-parser public package API."""
 
-__version__ = "2.6.0"
+__version__ = "2.7.0"
 __license__ = "MIT"
 
 from .converter import (


### PR DESCRIPTION
## Release v2.7.0

Promotes the accumulated `[Unreleased]` entries (#70, #71) to a dated `2.7.0` section and bumps the version in `pyproject.toml` and `slack_markdown_parser/__init__.py`.

**Minor bump rationale:** `normalize_bare_urls_for_slack_markdown` is newly exported as public API (new behavior for consumers), alongside the internal converter module split (behavior unchanged, AST-verified) and doc synchronization.

### Included changes

- **Added**: Export `normalize_bare_urls_for_slack_markdown` as part of the public package API (#70)
- **Changed**: Split `converter.py` into ten focused internal modules with an acyclic dependency graph; `converter.py` remains the orchestration module and re-exports every previously defined name (#71)
- **Changed**: Rename internal `looks_like_markdown_table` → `_looks_like_markdown_table` (#70)
- **Documentation**: README-ja lower-level helpers section, spec-ja mention-token sync, Quick start prose fix, CONTRIBUTING QA doc index (#70)

### Pre-release verification

- `pytest -q` — 207 passed (coverage 92%)
- `ruff check .` / `black --check .` — clean
- `python -m build` — 2.7.0 sdist + wheel built; wheel-install smoke test passed (public API resolution, converter import compatibility, real conversion)
- Docs consistency machine-checked: all 19 `__all__` names in both READMEs, spec pipeline order matches code, all six measured Slack limits match `_constants.py`

After merge: tag `v2.7.0` on the merge commit to trigger Trusted-Publisher PyPI publish and the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)